### PR TITLE
Updated shotover version to 0.7.0

### DIFF
--- a/cassandra-1-1/docker-compose.yaml
+++ b/cassandra-1-1/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     restart: always
     depends_on:
       - cassandra-one
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:cassandra-one"
     volumes:
       - .:/config
@@ -47,7 +47,7 @@ services:
     restart: always
     depends_on:
       - cassandra-two
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:cassandra-two"
     volumes:
       - .:/config
@@ -56,7 +56,7 @@ services:
     restart: always
     depends_on:
       - cassandra-three
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:cassandra-three"
     volumes:
       - .:/config

--- a/cassandra-1-many/docker-compose.yaml
+++ b/cassandra-1-many/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - cassandra-one
       - cassandra-two
       - cassandra-three
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     networks:
       cassandra_subnet:
         ipv4_address: 172.16.1.5

--- a/kafka-1-many/docker-compose.yaml
+++ b/kafka-1-many/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
       - kafka0
       - kafka1
       - kafka2
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.5

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -12,7 +12,7 @@ fn docker_compose(yaml_path: &str) -> DockerCompose {
 
 pub const IMAGE_WAITERS: [Image; 4] = [
     Image {
-        name: "shotover/shotover-proxy:v0.6.0",
+        name: "shotover/shotover-proxy:v0.7.0",
         log_regex_to_wait_for: r"accepting inbound connections",
         timeout: Duration::from_secs(120),
     },

--- a/valkey-backup-cluster/docker-compose.yaml
+++ b/valkey-backup-cluster/docker-compose.yaml
@@ -172,7 +172,7 @@ services:
         condition: service_healthy
       valkey-node-backup-5:
         condition: service_healthy
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     volumes:
       - .:/config
 

--- a/valkey-cluster-1-1/docker-compose.yaml
+++ b/valkey-cluster-1-1/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-0
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-0"
     volumes:
       - .:/config
@@ -84,7 +84,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-1
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-1"
     volumes:
       - .:/config
@@ -93,7 +93,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-2
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-2"
     volumes:
       - .:/config
@@ -102,7 +102,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-3
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-3"
     volumes:
       - .:/config
@@ -111,7 +111,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-4
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-4"
     volumes:
       - .:/config
@@ -120,7 +120,7 @@ services:
     restart: always
     depends_on:
       - valkey-node-5
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     network_mode: "service:valkey-node-5"
     volumes:
       - .:/config

--- a/valkey-cluster-1-many/docker-compose.yaml
+++ b/valkey-cluster-1-many/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
         condition: service_healthy
       valkey-node-5:
         condition: service_healthy
-    image: shotover/shotover-proxy:v0.6.0
+    image: shotover/shotover-proxy:v0.7.0
     volumes:
       - .:/config
 


### PR DESCRIPTION
As shotover 0.7.0 is released, bumping example's shotover version.